### PR TITLE
kernel: bump 5.4 to 5.4.71

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .70
+LINUX_VERSION-5.4 = .71
 
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.70 = c0b3d8085c5ba235df38b00b740e053659709e8a5ca21957a239f6bc22c45007
+LINUX_KERNEL_HASH-5.4.71 = 737049ef3cf38d46ee3b377354336cdbc1c4dd95b4e54975a70716f96c8d6cc7
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.4/950-0027-mm-Remove-the-PFN-busy-warning.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0027-mm-Remove-the-PFN-busy-warning.patch
@@ -14,7 +14,7 @@ Signed-off-by: Eric Anholt <eric@anholt.net>
 
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -8486,8 +8486,6 @@ int alloc_contig_range(unsigned long sta
+@@ -8489,8 +8489,6 @@ int alloc_contig_range(unsigned long sta
  
  	/* Make sure the range is really isolated. */
  	if (test_pages_isolated(outer_start, end, false)) {

--- a/target/linux/generic/hack-5.4/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-5.4/700-swconfig_switch_drivers.patch
@@ -12,7 +12,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -249,6 +249,89 @@ config LED_TRIGGER_PHY
+@@ -250,6 +250,89 @@ config LED_TRIGGER_PHY
  		for any speed known to the PHY.
  
  

--- a/target/linux/generic/pending-5.4/120-Fix-alloc_node_mem_map-with-ARCH_PFN_OFFSET-calcu.patch
+++ b/target/linux/generic/pending-5.4/120-Fix-alloc_node_mem_map-with-ARCH_PFN_OFFSET-calcu.patch
@@ -71,7 +71,7 @@ Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>
 
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
-@@ -6860,7 +6860,7 @@ static void __ref alloc_node_mem_map(str
+@@ -6861,7 +6861,7 @@ static void __ref alloc_node_mem_map(str
  		mem_map = NODE_DATA(0)->node_mem_map;
  #if defined(CONFIG_HAVE_MEMBLOCK_NODE_MAP) || defined(CONFIG_FLATMEM)
  		if (page_to_pfn(mem_map) != pgdat->node_start_pfn)

--- a/target/linux/generic/pending-5.4/752-net-phy-add-Broadcom-BCM84881-PHY-driver.patch
+++ b/target/linux/generic/pending-5.4/752-net-phy-add-Broadcom-BCM84881-PHY-driver.patch
@@ -18,7 +18,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -329,6 +329,12 @@ config BROADCOM_PHY
+@@ -330,6 +330,12 @@ config BROADCOM_PHY
  	  Currently supports the BCM5411, BCM5421, BCM5461, BCM54616S, BCM5464,
  	  BCM5481, BCM54810 and BCM5482 PHYs.
  

--- a/target/linux/ipq40xx/patches-5.4/700-net-add-qualcomm-mdio.patch
+++ b/target/linux/ipq40xx/patches-5.4/700-net-add-qualcomm-mdio.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -580,6 +580,13 @@ config XILINX_GMII2RGMII
+@@ -581,6 +581,13 @@ config XILINX_GMII2RGMII
  	  the Reduced Gigabit Media Independent Interface(RGMII) between
  	  Ethernet physical media devices and the Gigabit Ethernet controller.
  

--- a/target/linux/ipq40xx/patches-5.4/705-net-add-qualcomm-ar40xx-phy.patch
+++ b/target/linux/ipq40xx/patches-5.4/705-net-add-qualcomm-ar40xx-phy.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -587,6 +587,13 @@ config MDIO_IPQ40XX
+@@ -588,6 +588,13 @@ config MDIO_IPQ40XX
  	  This driver supports the MDIO interface found in Qualcomm
  	  Atheros ipq40xx Soc chip.
  

--- a/target/linux/layerscape/patches-5.4/701-net-0327-at803x-Address-packet-drops-at-low-traffic-rate-due-.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0327-at803x-Address-packet-drops-at-low-traffic-rate-due-.patch
@@ -22,7 +22,7 @@ Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -370,6 +370,16 @@ config AT803X_PHY
+@@ -371,6 +371,16 @@ config AT803X_PHY
  	---help---
  	  Currently supports the AT8030 and AT8035 model
  

--- a/target/linux/layerscape/patches-5.4/701-net-0328-net-phy-Inphi-IN112525_s03-retimer-support.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0328-net-phy-Inphi-IN112525_s03-retimer-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Florin Chiculita <florinlaurentiu.chiculita@nxp.com>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -478,6 +478,11 @@ config ICPLUS_PHY
+@@ -479,6 +479,11 @@ config ICPLUS_PHY
  	---help---
  	  Currently supports the IP175C and IP1001 PHYs.
  

--- a/target/linux/mediatek/patches-5.4/0003-switch-add-mt7531.patch
+++ b/target/linux/mediatek/patches-5.4/0003-switch-add-mt7531.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -332,6 +332,8 @@ config RTL8367B_PHY
+@@ -333,6 +333,8 @@ config RTL8367B_PHY
  
  endif # RTL8366_SMI
  

--- a/target/linux/uml/patches-5.4/101-mconsole-exec.patch
+++ b/target/linux/uml/patches-5.4/101-mconsole-exec.patch
@@ -153,7 +153,7 @@
  	pid_t pid;
 --- a/kernel/umh.c
 +++ b/kernel/umh.c
-@@ -75,6 +75,28 @@ static int call_usermodehelper_exec_asyn
+@@ -76,6 +76,28 @@ static int call_usermodehelper_exec_asyn
  	flush_signal_handlers(current, 1);
  	spin_unlock_irq(&current->sighand->siglock);
  
@@ -180,9 +180,9 @@
 +	}
 +
  	/*
- 	 * Our parent (unbound workqueue) runs with elevated scheduling
- 	 * priority. Avoid propagating that into the userspace child.
-@@ -353,6 +375,20 @@ static void helper_unlock(void)
+ 	 * Initial kernel threads share ther FS with init, in order to
+ 	 * get the init root directory. But we've now created a new
+@@ -362,6 +384,20 @@ static void helper_unlock(void)
  		wake_up(&running_helpers_waitq);
  }
  


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
