### PR TITLE
kernel: bump 5.4 to 5.4.84

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .83
+LINUX_VERSION-5.4 = .84
 
-LINUX_KERNEL_HASH-5.4.83 = beec970bbb93de8ab839f27930f7ab00c7bd65af0ffa07a50e765affdc2561c6
+LINUX_KERNEL_HASH-5.4.84 = 0985fcf6cdcebceca63cb70abab66d12e75fac61014a796ce71272b33f831515
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
@@ -32,7 +32,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  struct dpio_priv {
  	struct dpaa2_io *io;
  };
-@@ -200,13 +205,11 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -197,13 +202,11 @@ static int dpaa2_dpio_probe(struct fsl_m
  	if (dpio_dev->obj_desc.region_count < 3) {
  		/* No support for DDR backed portals, use classic mapping */
  		/*
@@ -50,7 +50,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  	} else {
  		desc.regs_cena = devm_memremap(dev, dpio_dev->regions[2].start,
  					resource_size(&dpio_dev->regions[2]),
-@@ -214,7 +217,7 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -211,7 +214,7 @@ static int dpaa2_dpio_probe(struct fsl_m
  	}
  
  	if (IS_ERR(desc.regs_cena)) {

--- a/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
@@ -35,7 +35,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  struct nxp_fspi {
  	void __iomem *iobase;
  	void __iomem *ahb_addr;
-@@ -1076,6 +1092,8 @@ static int nxp_fspi_resume(struct device
+@@ -1083,6 +1099,8 @@ static int nxp_fspi_resume(struct device
  
  static const struct of_device_id nxp_fspi_dt_ids[] = {
  	{ .compatible = "nxp,lx2160a-fspi", .data = (void *)&lx2160a_data, },

--- a/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
@@ -76,7 +76,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  	} else {
  		if (op->data.nbytes && op->data.dir == SPI_MEM_DATA_OUT)
  			nxp_fspi_fill_txfifo(f, op);
-@@ -992,9 +1018,8 @@ static int nxp_fspi_probe(struct platfor
+@@ -999,9 +1025,8 @@ static int nxp_fspi_probe(struct platfor
  
  	/* find the resources - controller memory mapped space */
  	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "fspi_mmap");
@@ -88,7 +88,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  		goto err_put_ctrl;
  	}
  
-@@ -1073,6 +1098,9 @@ static int nxp_fspi_remove(struct platfo
+@@ -1080,6 +1105,9 @@ static int nxp_fspi_remove(struct platfo
  
  	mutex_destroy(&f->lock);
  

--- a/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
+++ b/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
@@ -44,7 +44,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		mdio {
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -288,6 +288,7 @@
+@@ -291,6 +291,7 @@
  		resets = <&cru SRST_A_GMAC>;
  		reset-names = "stmmaceth";
  		rockchip,grf = <&grf>;


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
