### PR TITLE
kernel: bump 5.4 to 5.4.88

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .87
+LINUX_VERSION-5.4 = .88
 
-LINUX_KERNEL_HASH-5.4.87 = 6a34e93e2e84bb645155124962307ad9d3646124f43838d087209ed4ea595c31
+LINUX_KERNEL_HASH-5.4.88 = 4b8007c126c7146f020230fe19ce9924ba3b089c228002dea3ef54abba1824b2
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/mediatek/patches-5.4/0303-mtd-spinand-disable-on-die-ECC.patch
+++ b/target/linux/mediatek/patches-5.4/0303-mtd-spinand-disable-on-die-ECC.patch
@@ -11,7 +11,7 @@ Signed-off-by: Xiangsheng Hou <xiangsheng.hou@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -495,7 +495,7 @@ static int spinand_mtd_read(struct mtd_i
+@@ -491,7 +491,7 @@ static int spinand_mtd_read(struct mtd_i
  	int ret = 0;
  
  	if (ops->mode != MTD_OPS_RAW && spinand->eccinfo.ooblayout)
@@ -20,7 +20,7 @@ Signed-off-by: Xiangsheng Hou <xiangsheng.hou@mediatek.com>
  
  	mutex_lock(&spinand->lock);
  
-@@ -543,7 +543,7 @@ static int spinand_mtd_write(struct mtd_
+@@ -539,7 +539,7 @@ static int spinand_mtd_write(struct mtd_
  	int ret = 0;
  
  	if (ops->mode != MTD_OPS_RAW && mtd->ooblayout)


### PR DESCRIPTION
All modification made by update_kernel.sh in a fresh clone without
existing toolchains.

Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
