### PR TITLE
kernel: bump 5.4 to 5.4.92

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .91
+LINUX_VERSION-5.4 = .92
 
-LINUX_KERNEL_HASH-5.4.91 = 0e0161bb034b9ba59e58a20985e49ecfb38104586602f53f37b382f508fc5c17
+LINUX_KERNEL_HASH-5.4.92 = c0937ff98824c4b14cfea68a04340e0beb3c00f1cc02984daf2f3bdf542394fd
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/hack-5.4/721-phy_packets.patch
+++ b/target/linux/generic/hack-5.4/721-phy_packets.patch
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   */
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
-@@ -2679,6 +2679,10 @@ static inline int pskb_trim(struct sk_bu
+@@ -2684,6 +2684,10 @@ static inline int pskb_trim(struct sk_bu
  	return (len < skb->len) ? __pskb_trim(skb, len) : 0;
  }
  
@@ -67,7 +67,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   *	pskb_trim_unique - remove end from a paged unique (not cloned) buffer
   *	@skb: buffer to alter
-@@ -2810,16 +2814,6 @@ static inline struct sk_buff *dev_alloc_
+@@ -2815,16 +2819,6 @@ static inline struct sk_buff *dev_alloc_
  }
  
  
@@ -136,7 +136,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #include <net/protocol.h>
  #include <net/dst.h>
-@@ -540,6 +541,22 @@ skb_fail:
+@@ -545,6 +546,22 @@ skb_fail:
  }
  EXPORT_SYMBOL(__napi_alloc_skb);
  

--- a/target/linux/generic/pending-5.4/655-increase_skb_pad.patch
+++ b/target/linux/generic/pending-5.4/655-increase_skb_pad.patch
@@ -9,7 +9,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
-@@ -2645,7 +2645,7 @@ static inline int pskb_network_may_pull(
+@@ -2650,7 +2650,7 @@ static inline int pskb_network_may_pull(
   * NET_IP_ALIGN(2) + ethernet_header(14) + IP_header(20/40) + ports(8)
   */
  #ifndef NET_SKB_PAD

--- a/target/linux/layerscape/patches-5.4/303-core-0001-net-readd-skb_recycle.patch
+++ b/target/linux/layerscape/patches-5.4/303-core-0001-net-readd-skb_recycle.patch
@@ -24,7 +24,7 @@ Signed-off-by: Madalin Bucur <madalin.bucur@freescale.com>
  
 --- a/net/core/skbuff.c
 +++ b/net/core/skbuff.c
-@@ -936,6 +936,32 @@ void napi_consume_skb(struct sk_buff *sk
+@@ -941,6 +941,32 @@ void napi_consume_skb(struct sk_buff *sk
  }
  EXPORT_SYMBOL(napi_consume_skb);
  

--- a/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
+++ b/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
@@ -95,7 +95,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  
  	netif_tx_start_all_queues(port->dev);
-@@ -5139,8 +5143,11 @@ static void mvpp2_mac_config(struct phyl
+@@ -5137,8 +5141,11 @@ static void mvpp2_mac_config(struct phyl
  	mvpp2_port_enable(port);
  }
  


### PR DESCRIPTION
All modification made by update_kernel.sh in a fresh clone without
existing toolchains.

Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
